### PR TITLE
tests: add code coverage to PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build and test
 
+permissions:
+  pull-requests: write
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,5 +24,26 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
+      - name: Run all tests
+        run: dotnet test Money.sln /p:CollectCoverage=true /p:CoverletOutput=../../Assets/Coverage/ /p:MergeWith="../../Assets/Coverage/coverage.json" /p:CoverletOutputFormat=\"cobertura,json\" -m:1 --no-restore --verbosity normal
+
+      - name: Code coverage report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: /Assets/Coverage/coverage.cobertura.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: "50 70"
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          header: codeCoverage
+          recreate: true
+          path: code-coverage-results.md

--- a/src/Money.API/Configuration/AppServicesConfiguration.cs
+++ b/src/Money.API/Configuration/AppServicesConfiguration.cs
@@ -30,6 +30,8 @@ public static class AppServicesConfiguration
     {
         services.AddValidatorsFromAssemblyContaining<CreateParticipantRequestValidator>();
 
+        ValidatorOptions.Global.LanguageManager.Culture = new System.Globalization.CultureInfo("en-US");
+
         return services;
     }
 

--- a/src/Money.Migrations/Money.Migrations.csproj
+++ b/src/Money.Migrations/Money.Migrations.csproj
@@ -1,19 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.28" />
-    <PackageReference Include="FluentMigrator" Version="5.0.0" />
-    <PackageReference Include="FluentMigrator.Runner" Version="5.0.0" />
-    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="5.0.0" />
-    <PackageReference Include="Npgsql" Version="8.0.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Dapper" Version="2.1.28" />
+		<PackageReference Include="FluentMigrator" Version="5.0.0" />
+		<PackageReference Include="FluentMigrator.Runner" Version="5.0.0" />
+		<PackageReference Include="FluentMigrator.Runner.Postgres" Version="5.0.0" />
+		<PackageReference Include="Npgsql" Version="8.0.1" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+	</ItemGroup>
 
 </Project>

--- a/tests/Money.IntegrationTests/Money.IntegrationTests.csproj
+++ b/tests/Money.IntegrationTests/Money.IntegrationTests.csproj
@@ -10,6 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
@@ -17,18 +21,17 @@
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
 		<PackageReference Include="Respawn" Version="6.1.0" />
 		<PackageReference Include="Testcontainers.PostgreSql" Version="3.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\src\Money.API\Money.API.csproj" />
-	  <ProjectReference Include="..\..\src\Money.Domain\Money.Domain.csproj" />
-	  <ProjectReference Include="..\..\src\Money.Infrastructure\Money.Infrastructure.csproj" />
-	  <ProjectReference Include="..\..\src\Money.Migrations\Money.Migrations.csproj" />
-	  <ProjectReference Include="..\Money.TestsShared\Money.TestsShared.csproj" />
+		<ProjectReference Include="..\..\src\Money.API\Money.API.csproj" />
+		<ProjectReference Include="..\..\src\Money.Domain\Money.Domain.csproj" />
+		<ProjectReference Include="..\..\src\Money.Infrastructure\Money.Infrastructure.csproj" />
+		<ProjectReference Include="..\..\src\Money.Migrations\Money.Migrations.csproj" />
+		<ProjectReference Include="..\Money.TestsShared\Money.TestsShared.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/tests/Money.TestsShared/Money.TestsShared.csproj
+++ b/tests/Money.TestsShared/Money.TestsShared.csproj
@@ -1,19 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.3.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Bogus" Version="35.3.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Money.API\Money.API.csproj" />
-    <ProjectReference Include="..\..\src\Money.Domain\Money.Domain.csproj" />
-    <ProjectReference Include="..\..\src\Money.Infrastructure\Money.Infrastructure.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Money.API\Money.API.csproj" />
+		<ProjectReference Include="..\..\src\Money.Domain\Money.Domain.csproj" />
+		<ProjectReference Include="..\..\src\Money.Infrastructure\Money.Infrastructure.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+	</ItemGroup>
 
 </Project>

--- a/tests/Money.UnitTests/Money.UnitTests.csproj
+++ b/tests/Money.UnitTests/Money.UnitTests.csproj
@@ -10,11 +10,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="AutoBogus.FakeItEasy" Version="2.13.1" />


### PR DESCRIPTION
Every pull request from now on will contain a summary of the code coverage on the project. 

Similar to this one: 
![image](https://github.com/LucasRufo/money-rest-api/assets/60830097/083fbd59-9208-4ae4-93d6-aba751b92135)
